### PR TITLE
Make vid and callset mapping files configurable

### DIFF
--- a/bindings/genomicsdb.go
+++ b/bindings/genomicsdb.go
@@ -52,12 +52,14 @@ func ptr[T any](v T) *T {
 }
 
 type GenomicsDBQueryConfig struct {
-	Workspace       string
-	Array           string
-	ContigIntervals []*protobuf.ContigInterval
-	RowRanges       []*protobuf.RowRangeList
-	Attributes      []string
-	Filter          string
+	Workspace          string
+	Array              string
+	VidMappingFile     string
+	CallsetMappingFile string
+	ContigIntervals    []*protobuf.ContigInterval
+	RowRanges          []*protobuf.RowRangeList
+	Attributes         []string
+	Filter             string
 }
 
 func configure(queryConfig GenomicsDBQueryConfig) protobuf.ExportConfiguration {
@@ -66,10 +68,21 @@ func configure(queryConfig GenomicsDBQueryConfig) protobuf.ExportConfiguration {
 
 	exportConfig.Workspace = ptr(queryConfig.Workspace)
 	exportConfig.Array = &protobuf.ExportConfiguration_ArrayName{ArrayName: queryConfig.Array}
-	exportConfig.VidMappingInfo = &protobuf.ExportConfiguration_VidMappingFile{
-		VidMappingFile: filepath.Join(queryConfig.Workspace, "vidmap.json")}
-	exportConfig.CallsetMappingInfo = &protobuf.ExportConfiguration_CallsetMappingFile{
-		CallsetMappingFile: filepath.Join(queryConfig.Workspace, "callset.json"),
+	if len(queryConfig.VidMappingFile) > 0 {
+		exportConfig.VidMappingInfo = &protobuf.ExportConfiguration_VidMappingFile{
+			VidMappingFile: queryConfig.VidMappingFile}
+	} else {
+		exportConfig.VidMappingInfo = &protobuf.ExportConfiguration_VidMappingFile{
+			VidMappingFile: filepath.Join(queryConfig.Workspace, "vidmap.json"),
+		}
+	}
+	if len(queryConfig.CallsetMappingFile) > 0 {
+		exportConfig.CallsetMappingInfo = &protobuf.ExportConfiguration_CallsetMappingFile{
+			CallsetMappingFile: queryConfig.CallsetMappingFile}
+	} else {
+		exportConfig.CallsetMappingInfo = &protobuf.ExportConfiguration_CallsetMappingFile{
+			CallsetMappingFile: filepath.Join(queryConfig.Workspace, "callset.json"),
+		}
 	}
 	exportConfig.BypassIntersectingIntervalsPhase = ptr(true)
 	exportConfig.EnableSharedPosixfsOptimizations = ptr(true)

--- a/bindings/genomicsdb_test.go
+++ b/bindings/genomicsdb_test.go
@@ -29,6 +29,7 @@ package bindings
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -62,6 +63,32 @@ func TestQueryNonExistentWorkspace(t *testing.T) {
 
 func TestQuery(t *testing.T) {
 	config := createTestQueryConfig("test-ws", "allcontigs$1$3101976562")
+	config.ContigIntervals = []*protobuf.ContigInterval{
+		{Contig: ptr("1"), Begin: ptr(int64(1)), End: ptr(int64(20000))}}
+	config.RowRanges = []*protobuf.RowRangeList{
+		{RangeList: []*protobuf.RowRange{{Low: ptr(int64(0)), High: ptr(int64(2))}}}}
+	config.Attributes = []string{"GT", "DP"}
+	config.Filter = "REF == \"G\" && GT &= \"1/1\" && ALT |= \"T\""
+	succeeded, _, df := GenomicsDBQuery(config)
+
+	if !succeeded {
+		t.Fatal("TestQuery failed")
+	}
+
+	fmt.Println(df)
+}
+
+func createTestQueryConfigWithVidMappingAndCallsetMappingFiles(workspace string, array string) GenomicsDBQueryConfig {
+	return GenomicsDBQueryConfig{
+		Workspace:          workspace,
+		Array:              array,
+		VidMappingFile:     filepath.Join(workspace, "vidmap.json"),
+		CallsetMappingFile: filepath.Join(workspace, "callset.json"),
+	}
+}
+
+func TestQueryWithVidMappingAndCallsetMappingFiles(t *testing.T) {
+	config := createTestQueryConfigWithVidMappingAndCallsetMappingFiles("test-ws", "allcontigs$1$3101976562")
 	config.ContigIntervals = []*protobuf.ContigInterval{
 		{Contig: ptr("1"), Begin: ptr(int64(1)), End: ptr(int64(20000))}}
 	config.RowRanges = []*protobuf.RowRangeList{

--- a/install-genomicsdb/install.sh
+++ b/install-genomicsdb/install.sh
@@ -80,7 +80,11 @@ sed -i.bak -e '160d' CMakeLists.txt
 
 mkdir build
 pushd build
-cmake -DBUILD_FOR_GO=1 -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX .. || cleanup 1
+if [[ -n $OPENSSL_ROOT_DIR ]]; then
+  CMAKE_PREFIX_PATH="-DCMAKE_PREFIX_PATH=$OPENSSL_ROOT_DIR"
+fi
+
+cmake -DBUILD_FOR_GO=1 $CMAKE_PREFIX_PATH -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX -DAWSSDK_ROOT_DIR=$GENOMICSDB_DIR/awssdk -DGCSSDK_ROOT_DIR=$GENOMICSDB_DIR/gcssdk -DPROTOBUF_ROOT_DIR=$GENOMICSDB_DIR/protobuf .. || cleanup 1
 make -j4 || cleanup 1
 $SUDO make install
 popd


### PR DESCRIPTION
vid and callset mapping files are configurable via the `GenomicsDBQueryConfig` struct now. If not specified, the fallback is to join the workspace URI with `vidmap.json` and `callset.json` as `vcf2genomicsdb_init` and `gatk GenomicsDBImport` both create these files in the workspace.