### PR TITLE
Switch to net/url for joining GenomicsDB path URIs

### DIFF
--- a/bindings/genomicsdb.go
+++ b/bindings/genomicsdb.go
@@ -34,7 +34,7 @@ import "C"
 
 import (
 	"fmt"
-	"path/filepath"
+	"net/url"
 	"unsafe"
 
 	"github.com/GenomicsDB/GenomicsDB-Go/bindings/protobuf"
@@ -72,16 +72,24 @@ func configure(queryConfig GenomicsDBQueryConfig) protobuf.ExportConfiguration {
 		exportConfig.VidMappingInfo = &protobuf.ExportConfiguration_VidMappingFile{
 			VidMappingFile: queryConfig.VidMappingFile}
 	} else {
-		exportConfig.VidMappingInfo = &protobuf.ExportConfiguration_VidMappingFile{
-			VidMappingFile: filepath.Join(queryConfig.Workspace, "vidmap.json"),
+		vidMappingFile, err := url.JoinPath(queryConfig.Workspace, "vidmap.json")
+		if err != nil {
+			fmt.Println("vidMappingFile url.JoinPath error: ", err)
+		} else {
+			exportConfig.VidMappingInfo = &protobuf.ExportConfiguration_VidMappingFile{VidMappingFile: vidMappingFile}
 		}
 	}
 	if len(queryConfig.CallsetMappingFile) > 0 {
 		exportConfig.CallsetMappingInfo = &protobuf.ExportConfiguration_CallsetMappingFile{
 			CallsetMappingFile: queryConfig.CallsetMappingFile}
 	} else {
-		exportConfig.CallsetMappingInfo = &protobuf.ExportConfiguration_CallsetMappingFile{
-			CallsetMappingFile: filepath.Join(queryConfig.Workspace, "callset.json"),
+		callsetMappingFile, err := url.JoinPath(queryConfig.Workspace, "callset.json")
+		if err != nil {
+			fmt.Println("callsetMappingFile url.JoinPath error: ", err)
+		} else {
+			exportConfig.CallsetMappingInfo = &protobuf.ExportConfiguration_CallsetMappingFile{
+				CallsetMappingFile: callsetMappingFile,
+			}
 		}
 	}
 	exportConfig.BypassIntersectingIntervalsPhase = ptr(true)

--- a/bindings/genomicsdb_test.go
+++ b/bindings/genomicsdb_test.go
@@ -61,6 +61,30 @@ func TestQueryNonExistentWorkspace(t *testing.T) {
 	}
 }
 
+func TestQueryWorkspaceWithInvalidURL(t *testing.T) {
+	succeeded, errMsg, _ := GenomicsDBQuery(createTestQueryConfig("azb://my Container/myPath?endpoint=foo.blob.core.windows.net", "non-existent-array"))
+	if succeeded {
+		t.Fatal("TestQueryNonExistentWorkspace should not succeed")
+	} else if len(errMsg) == 0 {
+		t.Fatal("TestQueryNonExistentWorkspace should return error message")
+	}
+	if len(errMsg) == 0 {
+		t.Fatal("No error message from failed Query")
+	}
+}
+
+func TestQueryWorkspaceWithNonExistentWorkspaceURL(t *testing.T) {
+	succeeded, errMsg, _ := GenomicsDBQuery(createTestQueryConfig("azb://myContainer/non-existent-workspace?endpoint=foo.blob.core.windows.net", "non-existent-array"))
+	if succeeded {
+		t.Fatal("TestQueryNonExistentWorkspace should not succeed")
+	} else if len(errMsg) == 0 {
+		t.Fatal("TestQueryNonExistentWorkspace should return error message")
+	}
+	if len(errMsg) == 0 {
+		t.Fatal("No error message from failed Query")
+	}
+}
+
 func TestQuery(t *testing.T) {
 	config := createTestQueryConfig("test-ws", "allcontigs$1$3101976562")
 	config.ContigIntervals = []*protobuf.ContigInterval{


### PR DESCRIPTION
Replaced `filepath.join` with `url.joinPath` to allow for cloud paths to be appended together correctly. Added test cases to exercise the error conditions.