### PR TITLE
Workaround for GenomicsDB shared library not being found on macOS Sonoma

### DIFF
--- a/bindings/genomicsdb.go
+++ b/bindings/genomicsdb.go
@@ -27,6 +27,9 @@
 package bindings
 
 // #cgo pkg-config: genomicsdb
+// #if defined(__APPLE__)
+// #cgo LDFLAGS: -Wl,-rpath,/usr/local/lib
+// #endif
 // #cgo CXXFLAGS: -std=c++14
 // #include <genomicsdb_go.h>
 // #include <stdlib.h>

--- a/install-genomicsdb/install.sh
+++ b/install-genomicsdb/install.sh
@@ -79,6 +79,8 @@ if [[ $(uname) == "Darwin" ]]; then
   export OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
   # Use the uuid from framework
   brew list ossp-uuid &> /dev/null && brew uninstall ossp-uuid
+  brew list automake &> /dev/null || brew install automake
+  brew list pkg-config &> /dev/null || brew install pkg-config
 else
   PREREQS_ENV=$GENOMICSDB_DIR/prereqs.sh $SUDO scripts/prereqs/install_prereqs.sh
 fi


### PR DESCRIPTION
Looks like on macOS Sonoma `/usr/local/lib` is no longer a default library path causing errors like the following -
```
~/example-genomicsdb-go: go run .
dyld[19313]: Library not loaded: @rpath/libtiledbgenomicsdb.1.dylib
  Referenced from: <09127B12-1C57-3487-BF04-73BE8B7E7594> /private/var/folders/bt/5nzj1pzj2bv0spxhcshx4n780000gn/T/go-build384721403/b001/exe/example-genomicsdb-go
  Reason: no LC_RPATH's found
signal: abort trap
```
For now, adding an explicit path via - `-Wl,-rpath,...` in `genomicsdb.go` and also setting env `DYLD_FALLBACK_LIBRARY_PATH`(not really necessary because of `-Wl,-rpath`) until it is more clear on how default library paths are handled.